### PR TITLE
Avoid over-constraining selftype of EnumMeta (#1770)

### DIFF
--- a/stdlib/3.4/enum.pyi
+++ b/stdlib/3.4/enum.pyi
@@ -2,7 +2,7 @@ import sys
 from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized, Reversible, Container, Mapping
 from abc import ABCMeta
 
-_T = TypeVar('_T', bound=Enum)
+_T = TypeVar('_T')
 _S = TypeVar('_S', bound=Type[Enum])
 
 # Note: EnumMeta actually subclasses type directly, not ABCMeta.


### PR DESCRIPTION
This is needed for python/mypy#4311, and is sound.